### PR TITLE
Move global variables into a context object for safety

### DIFF
--- a/negamax.h
+++ b/negamax.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "game.h"
 typedef struct {
     int score, move;
 } move_t;
@@ -8,6 +8,7 @@ typedef struct {
     int history_score_sum[N_GRIDS];
     int history_count[N_GRIDS];
     u64 hash_value;
+    u64 zobrist_table[N_GRIDS][2];
 } negamax_context_t;
 
 void negamax_init(void);

--- a/zobrist.c
+++ b/zobrist.c
@@ -2,8 +2,6 @@
 
 #include "zobrist.h"
 
-u64 zobrist_table[N_GRIDS][2];
-
 #define HASH(key) ((key) % HASH_TABLE_SIZE)
 
 static struct hlist_head *hash_table;
@@ -27,12 +25,12 @@ static u64 wyhash64(void)
     return wyhash64_stateless(&seed);
 }
 
-void zobrist_init(void)
+void zobrist_init(negamax_context_t *ctx)
 {
     int i;
     for (i = 0; i < N_GRIDS; i++) {
-        zobrist_table[i][0] = wyhash64();
-        zobrist_table[i][1] = wyhash64();
+        ctx->zobrist_table[i][0] = wyhash64();
+        ctx->zobrist_table[i][1] = wyhash64();
     }
     hash_table =
         kmalloc(sizeof(struct hlist_head) * HASH_TABLE_SIZE, GFP_KERNEL);

--- a/zobrist.h
+++ b/zobrist.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <linux/list.h>
+#include "negamax.h"
 
 #include "game.h"
 
 #define HASH_TABLE_SIZE (100003)
 
-extern u64 zobrist_table[N_GRIDS][2];
+// extern u64 zobrist_table[N_GRIDS][2];
 
 typedef struct {
     u64 key;
@@ -15,7 +16,7 @@ typedef struct {
     struct hlist_node ht_list;
 } zobrist_entry_t;
 
-void zobrist_init(void);
+void zobrist_init(negamax_context_t *ctx);
 zobrist_entry_t *zobrist_get(u64 key);
 void zobrist_put(u64 key, int score, int move);
 void zobrist_clear(void);


### PR DESCRIPTION
move previous globle variable inside a struct
use a static pointer to provide context during sorting and add a lock for sort to prevent data races in concurrent